### PR TITLE
Update auto_ptr_custom.h

### DIFF
--- a/auto_ptr_custom.h
+++ b/auto_ptr_custom.h
@@ -23,6 +23,9 @@ public:
 	auto_ptr_custom(auto_ptr_custom& copyMe) : _ptr( copyMe.release() ) { 
 	}
 	
+	auto_ptr_custom(const auto_ptr_custom<T,Deleter>& copyMe):_ptr(copyMe._ptr) { 
+	}
+	
 	auto_ptr_custom& operator=(auto_ptr_custom<T,Deleter>& rhs) { 
 		_ptr = rhs.release();
    		return *this;


### PR DESCRIPTION
The reason for compiler error is, compiler created temporary objects cannot be bound to non-const references and the original program tries to do that. It doesn’t make sense to modify compiler created temporary objects as they can die any moment.
